### PR TITLE
Add a timeout wrapper

### DIFF
--- a/app/post/PostAction.scala
+++ b/app/post/PostAction.scala
@@ -1,13 +1,16 @@
 package post
 
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
+import akka.actor.ActorSystem
 import com.codahale.metrics.MetricRegistry
 import nl.grons.metrics.scala.InstrumentedBuilder
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 
 /**
  * The default action for the Post resource.
@@ -18,6 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
  */
 class PostAction @Inject()(config: PostActionConfig,
                            messagesApi: MessagesApi,
+                           actorSystem: ActorSystem,
                            val metricRegistry: MetricRegistry)(implicit ec: ExecutionContext)
   extends ActionBuilder[PostRequest] with InstrumentedBuilder {
 
@@ -31,6 +35,8 @@ class PostAction @Inject()(config: PostActionConfig,
 
   private val maxAge = config.maxAge.getSeconds
 
+  private val timeoutDuration = FiniteDuration(config.timeout.toMillis, TimeUnit.MILLISECONDS)
+
   override def invokeBlock[A](request: Request[A], block: PostRequestBlock[A]): Future[Result] = {
     if (logger.isTraceEnabled) {
       logger.trace(s"invokeBlock: request = $request")
@@ -39,18 +45,34 @@ class PostAction @Inject()(config: PostActionConfig,
     // Count the number of requests
     requestsMeter.mark()
 
-    // Measures the wall clock time to execute the action
-    wallClockTimer.timeFuture {
-      val messages = messagesApi.preferred(request)
-      val postRequest = new PostRequest(request, messages)
-      block(postRequest).map { result =>
-        if (postRequest.method == "GET") {
-          result.withHeaders(("Cache-Control", s"max-age: $maxAge"))
-        } else {
-          result
+    // Fail the backend futures if they take more than the timeout
+    withTimeout {
+      // Measures the wall clock time to execute the action
+      wallClockTimer.timeFuture {
+        val messages = messagesApi.preferred(request)
+        val postRequest = new PostRequest(request, messages)
+        block(postRequest).map { result =>
+          if (postRequest.method == "GET") {
+            result.withHeaders(("Cache-Control", s"max-age: $maxAge"))
+          } else {
+            result
+          }
         }
       }
+    }.recoverWith {
+      case e: TimeoutException =>
+        logger.error(s"Future timeout on request $request", e)
+        Future.successful(Results.ServiceUnavailable)
     }
+  }
+
+  private def withTimeout[A](result: => Future[Result]): Future[Result] = {
+    val timeoutResult = akka.pattern.after(timeoutDuration, actorSystem.scheduler) {
+      val msg = s"Timeout after $timeoutDuration"
+      Future.failed(new TimeoutException(msg))
+    }(actorSystem.dispatchers.defaultGlobalDispatcher)
+
+    Future.firstCompletedOf(Seq(result, timeoutResult))
   }
 }
 
@@ -63,5 +85,6 @@ class PostAction @Inject()(config: PostActionConfig,
 class PostRequest[A](request: Request[A], val messages: Messages)
   extends WrappedRequest(request) {
   def flashSuccess: Option[String] = request.flash.get("success")
+
   def flashError: Option[String] = request.flash.get("error")
 }

--- a/app/post/PostActionConfig.scala
+++ b/app/post/PostActionConfig.scala
@@ -9,11 +9,12 @@ import java.time.Duration
  *
  * @param maxAge the maximum age the response should be cached for.
  */
-final case class PostActionConfig(maxAge: Duration)
+final case class PostActionConfig(maxAge: Duration, timeout: Duration)
 
 object PostActionConfig {
   def fromConfiguration(config: Config): PostActionConfig = {
-    val d = config.getDuration("restapi.postAction.maxAge")
-    PostActionConfig(d)
+    val maxAge = config.getDuration("restapi.postAction.maxAge")
+    val timeout = config.getDuration("restapi.postAction.timeout")
+    PostActionConfig(maxAge, timeout)
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -3,6 +3,7 @@ include "secure"
 # Settings specific to the REST API.
 restapi {
   postAction.maxAge = 5 minutes
+  postAction.timeout = 1 second
 
   postRepository {
     dispatcher {

--- a/modules/comment/src/main/scala/com/lightbend/blog/comment/CommentRepository.scala
+++ b/modules/comment/src/main/scala/com/lightbend/blog/comment/CommentRepository.scala
@@ -40,7 +40,7 @@ trait CommentRepositoryLifecycle {
  * strongly typed execution context so that an inappropriate ExecutionContext can't
  * be used by accident.
  */
-class CommentExecutionContext(val underlying: ExecutionContext) extends AnyVal
+class CommentExecutionContext(val underlying: ExecutionContext)
 
 /**
  * A trivial implementation for the Comment Repository.

--- a/modules/post/src/main/scala/com/lightbend/blog/post/PostRepository.scala
+++ b/modules/post/src/main/scala/com/lightbend/blog/post/PostRepository.scala
@@ -37,7 +37,7 @@ trait PostRepositoryLifecycle {
  * strongly typed execution context so that an inappropriate ExecutionContext can't
  * be used by accident.
  */
-class PostExecutionContext(val underlying: ExecutionContext) extends AnyVal
+class PostExecutionContext(val underlying: ExecutionContext)
 
 /**
  * A trivial implementation for the Post Repository.
@@ -63,14 +63,14 @@ class PostRepositoryImpl @Inject()(pec: PostExecutionContext) extends PostReposi
 
   override def list(): Future[Iterable[PostData]] = {
     Future {
-      logger.trace("list: ")
+      logger.trace(s"list: using ${ec}")
       postList
     }
   }
 
   override def get(id: PostId): Future[Option[PostData]] = {
     Future {
-      logger.trace(s"get: id = $id")
+      logger.trace(s"get: using ${ec} id = $id")
       postList.find(post => post.id == id)
     }
   }


### PR DESCRIPTION
Adds a timeout wrapper to PostAction.

Also fixes the AnyVal problem (because Guice is runtime DI, it can't distinguish PostExecutionContext from plain ExecutionContext)
