### PR TITLE
Simplify PostRouter

### DIFF
--- a/app/post/PostHandler.scala
+++ b/app/post/PostHandler.scala
@@ -1,0 +1,79 @@
+package post
+
+import javax.inject.Inject
+
+import circuitbreaker._
+import com.lightbend.blog.comment._
+import com.lightbend.blog.post._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+ * Controls access to the repositories, returning [[Post]] and [[Comment]].
+ */
+class PostHandler @Inject()(postRepository: PostRepository,
+                            commentRepository: CommentRepository,
+                            val failsafeBuilder: FailsafeBuilder)
+                           (implicit ec: ExecutionContext)
+  extends CircuitBreaker {
+
+  /**
+   * Creates a post in the repository.
+   */
+  def create[A](postInput: PostFormInput): Future[Post] = {
+    val data = PostData(PostId("999"), postInput.title, postInput.body)
+    breaker.async { _ =>
+      // We don't actually create the post, so return what we have
+      postRepository.create(data).map { id =>
+        Post(data, Seq.empty)
+      }
+    }
+  }
+
+  /**
+   * Looks up a single Post from the repository.
+   */
+  def lookup[A](id: String): Future[Option[Post]] = {
+    breaker.async { _ =>
+      val postFuture = postRepository.get(PostId(id))
+      val commentsFuture = findComments(id)
+      postFuture.flatMap { maybePostData =>
+        commentsFuture.map { comments =>
+          maybePostData.map(Post(_, comments))
+        }
+      }
+    }
+  }
+
+  /**
+   * Finds all posts.
+   */
+  def find: Future[Iterable[Post]] = {
+    breaker.async { _ =>
+      postRepository.list().flatMap { postDataList =>
+        // Get an Iterable[Future[Post]] containing comments
+        val listOfFutures = postDataList.map { p =>
+          findComments(p.id.toString).map { comments =>
+            Post(p, comments)
+          }
+        }
+
+        // Flip it into a single Future[Iterable[Post]]
+        Future.sequence(listOfFutures)
+      }
+    }
+  }
+
+  /**
+   * Finds comments in the repository.
+   */
+  private def findComments(postId: String): Future[Seq[Comment]] = {
+    breaker.async { _ =>
+      // Find all the comments for this post
+      commentRepository.findByPost(postId.toString).map { comments =>
+        comments.map(c => Comment(c.body)).toSeq
+      }
+    }
+  }
+
+}

--- a/app/post/PostRouter.scala
+++ b/app/post/PostRouter.scala
@@ -1,16 +1,10 @@
 package post
 
 import javax.inject.Inject
-import java.util.concurrent._
-
-import com.lightbend.blog.comment._
-import com.lightbend.blog.post._
-import circuitbreaker._
 
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.http.MimeTypes
-import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.Json
 import play.api.mvc.Results._
 import play.api.mvc._
@@ -23,42 +17,12 @@ import scala.concurrent.{ExecutionContext, Future}
 case class PostFormInput(title: String, body: String)
 
 /**
- * Takes HTTP requests and produces JSON or HTML responses
- * from a repository providing data.
+ * Takes HTTP requests and produces JSON or HTML responses.
  */
 class PostRouter @Inject()(action: PostAction,
-                           postRepository: PostRepository,
-                           commentRepository: CommentRepository,
-                           lifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext)
-  extends SimpleRouter with RequestExtractors with Rendering with CircuitBreaker {
-
-  val failsafeBuilder = new FailsafeBuilder {
-    import net.jodah.failsafe._
-
-    val scheduler: ScheduledExecutorService = {
-      val s = Executors.newScheduledThreadPool(2)
-      lifecycle.addStopHook(() => Future.successful(s.shutdown()))
-      s
-    }
-
-    val circuitBreaker = {
-      val breaker = new CircuitBreaker()
-        .withFailureThreshold(3)
-        .withSuccessThreshold(1)
-        .withDelay(5, TimeUnit.SECONDS)
-      breaker
-    }
-
-    def sync[R]: SyncFailsafe[R] = {
-      Failsafe.`with`(circuitBreaker)
-    }
-
-    def async[R]: AsyncFailsafe[R] = {
-      sync.`with`(scheduler)
-    }
-  }
-
-  private val logger = org.slf4j.LoggerFactory.getLogger(this.getClass)
+                           postHandler: PostHandler)
+                          (implicit ec: ExecutionContext)
+  extends SimpleRouter with AcceptExtractors with Rendering {
 
   private val form = Form(
     mapping(
@@ -68,13 +32,7 @@ class PostRouter @Inject()(action: PostAction,
   )
 
   override def routes: Routes = {
-
     case GET(p"/") =>
-      action.async { implicit request =>
-        renderPosts()
-      }
-
-    case HEAD(p"/") =>
       action.async { implicit request =>
         renderPosts()
       }
@@ -86,148 +44,93 @@ class PostRouter @Inject()(action: PostAction,
 
     case GET(p"/$id") =>
       action.async { implicit request =>
-        renderPost(PostId(id))
+        renderPost(id)
       }
 
-    case HEAD(p"/$id") =>
-      action.async { implicit request =>
-        renderPost(PostId(id))
-      }
+  }
+
+  private def renderPosts[A]()(implicit request: PostRequest[A]): Future[Result] = {
+    render.async {
+
+      case Accepts.Json() =>
+        postHandler.find.map { posts =>
+          Results.Ok(Json.toJson(posts))
+        }
+
+      case Accepts.Html() =>
+        postHandler.find.map { posts =>
+          Results.Ok(views.html.posts.index(posts, form))
+        }
+    }
   }
 
   private def processPost[A]()(implicit request: PostRequest[A]): Future[Result] = {
     request.contentType match {
       case Some(MimeTypes.JSON) =>
-        form.bindFromRequest().fold(hasErrors = { badForm =>
-          Future.successful {
-            Results.BadRequest(badForm.errorsAsJson)
-          }
-        }, success = { postInput =>
-          createPost(postInput).map { post =>
-            Results.Created(Json.toJson(post))
-              .withHeaders("Location" -> post.link)
-          }
-        })
+        processJsonPost()
 
       case Some(MimeTypes.FORM) =>
-        form.bindFromRequest().fold(hasErrors = { badForm =>
-          Future.successful {
-            Results.BadRequest(views.html.posts.create(badForm))
-              .withFlashError("Could not create post!")
-          }
-        }, success = { postInput =>
-          createPost(postInput).map { post =>
-            Results.Redirect(request.uri)
-              .withFlashSuccess(s"Created post $post")
-          }
-        })
+        processHtmlPost()
 
       case other =>
         Future.successful(UnsupportedMediaType)
     }
   }
 
-  private def renderPost[A](id: PostId)(implicit request: PostRequest[A]): Future[Result] = {
-    logger.trace("renderPost: ")
-    // Find a single item from the repository
+  private def processJsonPost[A]()(implicit request: PostRequest[A]): Future[Result] = {
+    def failure(badForm: Form[PostFormInput]) = {
+      Future.successful(Results.BadRequest(badForm.errorsAsJson))
+    }
+
+    def success(input: PostFormInput) = {
+      postHandler.create(input).map { post =>
+        Results.Created(Json.toJson(post))
+          .withHeaders("Location" -> post.link)
+      }
+    }
+
+    form.bindFromRequest().fold(failure, success)
+  }
+
+  private def processHtmlPost[A]()(implicit request: PostRequest[A]): Future[Result] = {
+    def failure(badForm: Form[PostFormInput]) = {
+      Future.successful {
+        Results.BadRequest(views.html.posts.create(badForm))
+          .withFlashError("Could not create post!")
+      }
+    }
+
+    def success(input: PostFormInput) = {
+      postHandler.create(input).map { post =>
+        Results.Redirect(request.uri)
+          .withFlashSuccess(s"Created post $post")
+      }
+    }
+
+    form.bindFromRequest().fold(failure, success)
+  }
+
+  private def renderPost[A](id: String)(implicit request: PostRequest[A]): Future[Result] = {
     render.async {
 
-      case Accepts.Json() & Accepts.Html() if request.method == "HEAD" =>
-        // Do not render a body on HEAD
-        findPost(id).flatMap {
-          case Some(p) =>
-            Future.successful(Results.Ok)
-          case None =>
-            Future.successful(Results.NotFound)
-        }
-
       case Accepts.Json() =>
-        findPost(id).flatMap {
-          case Some(p) =>
-            findComments(p.id).map { comments =>
-              val post = Post(p, comments)
-              val json = Json.toJson(post)
-              Results.Ok(json)
-            }
+        postHandler.lookup(id).map {
+          case Some(post) =>
+            Results.Ok(Json.toJson(post))
           case None =>
-            Future.successful(Results.NotFound)
+            Results.NotFound
         }
 
       case Accepts.Html() =>
-        findPost(id).flatMap {
-          case Some(p) =>
-            findComments(p.id).map { comments =>
-              val post = Post(p, comments)
-              Results.Ok(views.html.posts.show(post))
-            }
+        postHandler.lookup(id).map {
+          case Some(post) =>
+            Results.Ok(views.html.posts.show(post))
           case None =>
-            Future.successful(Results.NotFound)
+            Results.NotFound
         }
-
-    }
-  }
-
-  private def renderPosts[A]()(implicit request: PostRequest[A]): Future[Result] = {
-    render.async {
-
-      case Accepts.Json() & Accepts.Html() if request.method == "HEAD" =>
-        // HEAD has no body, so just say hi
-        Future.successful(Results.Ok)
-
-      case Accepts.Json() =>
-        // Query the repository for available posts
-        findPosts().map { posts =>
-          val json = Json.toJson(posts)
-          Results.Ok(json)
-        }
-
-      case Accepts.Html() =>
-        // Query the repository for available posts
-        findPosts().map { posts =>
-          Results.Ok(views.html.posts.index(posts, form))
-        }
-    }
-  }
-
-  private def createPost[A](postInput: PostFormInput): Future[Post] = {
-    breaker.async { _ =>
-      val data = PostData(PostId("999"), postInput.title, postInput.body)
-      // we don't actually create the post, so return what we have
-      postRepository.create(data).map { id =>
-        Post(data, Seq.empty)
-      }
-    }
-  }
-
-  private def findPost[A](id: PostId): Future[Option[PostData]] = {
-    breaker.async { _ =>
-      postRepository.get(id)
-    }
-  }
-
-  private def findPosts(): Future[Iterable[Post]] = {
-    breaker.async { _ =>
-      postRepository.list().flatMap { postDataList =>
-        // Get an Iterable[Future[Post]] containing comments
-        val listOfFutures = postDataList.map { p =>
-          findComments(p.id).map { comments =>
-            Post(p, comments)
-          }
-        }
-
-        // Flip it into a single Future[Iterable[Post]]
-        Future.sequence(listOfFutures)
-      }
-    }
-  }
-
-  private def findComments(postId: PostId): Future[Seq[Comment]] = {
-    breaker.async { _ =>
-      // Find all the comments for this post
-      commentRepository.findByPost(postId.toString).map { comments =>
-        comments.map(c => Comment(c.body)).toSeq
-      }
     }
   }
 
 }
+
+


### PR DESCRIPTION
Move out the repository handling logic to a PostHandler.
Clean up some HEAD logic bugs.
Move out the FailsafeBuilder from the router.

Based on review with @schmitch
