### PR TITLE
Add download_url property so we can display download button

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,4 +23,7 @@ lazy val root = (project in file("."))
 // Documentation for this project:
 //    sbt "project docs" "~ paradox"
 //    open docs/target/paradox/site/index.html
-lazy val docs = (project in file("docs")).enablePlugins(ParadoxPlugin)
+lazy val docs = (project in file("docs")).enablePlugins(ParadoxPlugin).
+  settings(
+    paradoxProperties += ("download_url" -> "https://example.lightbend.com/v1/download/play-rest-api")
+  )

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,8 +1,7 @@
 // You will need private bintray credentials to publish this with Lightbend theme
 // credentials += Credentials("Bintray", "dl.bintray.com", "<user>", "<bintray API key>")
-//resolvers += "bintray-typesafe-internal-maven-releases" at "https://dl.bintray.com/typesafe/internal-maven-releases/"
-//libraryDependencies += "com.lightbend.paradox" % "paradox-theme-lightbend" % "0.2.1-TH2"
-//paradoxTheme := Some("com.lightbend.paradox" % "paradox-theme-lightbend" % "0.2.1-TH2")
+// resolvers += "bintray-typesafe-internal-maven-releases" at "https://dl.bintray.com/typesafe/internal-maven-releases/"
+// paradoxTheme := Some("com.lightbend.paradox" % "paradox-theme-lightbend" % "0.2.3")
 
 // Uses the out of the box generic theme.
 paradoxTheme := Some(builtinParadoxTheme("generic"))


### PR DESCRIPTION
The latest theme can pick up "download_url" property and display the download button:

![basics_ _making_a_rest_api_with_play](https://cloud.githubusercontent.com/assets/184683/19534673/b67aff5c-9612-11e6-97d9-57d7654863b1.png)
