### PR TITLE
Update to 2.12 and update libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 sudo: true
 group: beta
 scala:
-- 2.11.11
+- 2.12.3
 jdk:
 - oraclejdk8
 cache:

--- a/app/RequestHandler.scala
+++ b/app/RequestHandler.scala
@@ -19,7 +19,8 @@ class RequestHandler @Inject()(router: Router,
                                       configuration,
                                       filters) {
 
-  override def handlerForRequest(request: RequestHeader): (RequestHeader, Handler) = {
+  override def handlerForRequest(
+      request: RequestHeader): (RequestHeader, Handler) = {
     super.handlerForRequest {
       // ensures that REST API does not need a trailing "/"
       if (isREST(request)) {

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -7,7 +7,8 @@ import play.api.mvc._
 /**
   * A very small controller that renders a home page.
   */
-class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+class HomeController @Inject()(cc: ControllerComponents)
+    extends AbstractController(cc) {
 
   def index = Action { implicit request =>
     Ok(views.html.index())

--- a/app/v1/post/PostActionBuilder.scala
+++ b/app/v1/post/PostActionBuilder.scala
@@ -17,12 +17,16 @@ import scala.language.implicitConversions
   * This is commonly used to hold request-specific information like
   * security credentials, and useful shortcut methods.
   */
-trait PostRequestHeader extends MessagesRequestHeader with PreferredMessagesProvider
-class PostRequest[A](request: Request[A], val messagesApi: MessagesApi) extends WrappedRequest(request) with PostRequestHeader
+trait PostRequestHeader
+    extends MessagesRequestHeader
+    with PreferredMessagesProvider
+class PostRequest[A](request: Request[A], val messagesApi: MessagesApi)
+    extends WrappedRequest(request)
+    with PostRequestHeader
 
 /**
- * Provides an implicit marker that will show the request in all logger statements.
- */
+  * Provides an implicit marker that will show the request in all logger statements.
+  */
 trait RequestMarkerContext {
   import net.logstash.logback.marker.Markers
 
@@ -32,9 +36,11 @@ trait RequestMarkerContext {
     def &&(marker2: LogstashMarker): LogstashMarker = marker1.and(marker2)
   }
 
-  implicit def requestHeaderToMarkerContext(implicit request: RequestHeader): MarkerContext = {
+  implicit def requestHeaderToMarkerContext(
+      implicit request: RequestHeader): MarkerContext = {
     MarkerContext {
-      marker("id" -> request.id) && marker("host" -> request.host) && marker("remoteAddress" -> request.remoteAddress)
+      marker("id" -> request.id) && marker("host" -> request.host) && marker(
+        "remoteAddress" -> request.remoteAddress)
     }
   }
 
@@ -47,8 +53,9 @@ trait RequestMarkerContext {
   * the request with contextual data, and manipulate the
   * result.
   */
-class PostActionBuilder @Inject()(messagesApi: MessagesApi, playBodyParsers: PlayBodyParsers)
-                                 (implicit val executionContext: ExecutionContext)
+class PostActionBuilder @Inject()(messagesApi: MessagesApi,
+                                  playBodyParsers: PlayBodyParsers)(
+    implicit val executionContext: ExecutionContext)
     extends ActionBuilder[PostRequest, AnyContent]
     with RequestMarkerContext
     with HttpVerbs {
@@ -62,7 +69,8 @@ class PostActionBuilder @Inject()(messagesApi: MessagesApi, playBodyParsers: Pla
   override def invokeBlock[A](request: Request[A],
                               block: PostRequestBlock[A]): Future[Result] = {
     // Convert to marker context and use request in block
-    implicit val markerContext: MarkerContext = requestHeaderToMarkerContext(request)
+    implicit val markerContext: MarkerContext = requestHeaderToMarkerContext(
+      request)
     logger.trace(s"invokeBlock: ")
 
     val future = block(new PostRequest(request, messagesApi))
@@ -79,25 +87,28 @@ class PostActionBuilder @Inject()(messagesApi: MessagesApi, playBodyParsers: Pla
 }
 
 /**
- * Packages up the component dependencies for the post controller.
- *
- * This is a good way to minimize the surface area exposed to the controller, so the
- * controller only has to have one thing injected.
- */
-case class PostControllerComponents @Inject()(postActionBuilder: PostActionBuilder,
-                                               postResourceHandler: PostResourceHandler,
-                                               actionBuilder: DefaultActionBuilder,
-                                               parsers: PlayBodyParsers,
-                                               messagesApi: MessagesApi,
-                                               langs: Langs,
-                                               fileMimeTypes: FileMimeTypes,
-                                               executionContext: scala.concurrent.ExecutionContext)
-  extends ControllerComponents
+  * Packages up the component dependencies for the post controller.
+  *
+  * This is a good way to minimize the surface area exposed to the controller, so the
+  * controller only has to have one thing injected.
+  */
+case class PostControllerComponents @Inject()(
+    postActionBuilder: PostActionBuilder,
+    postResourceHandler: PostResourceHandler,
+    actionBuilder: DefaultActionBuilder,
+    parsers: PlayBodyParsers,
+    messagesApi: MessagesApi,
+    langs: Langs,
+    fileMimeTypes: FileMimeTypes,
+    executionContext: scala.concurrent.ExecutionContext)
+    extends ControllerComponents
 
 /**
- * Exposes actions and handler to the PostController by wiring the injected state into the base class.
- */
-class PostBaseController @Inject()(pcc: PostControllerComponents) extends BaseController with RequestMarkerContext {
+  * Exposes actions and handler to the PostController by wiring the injected state into the base class.
+  */
+class PostBaseController @Inject()(pcc: PostControllerComponents)
+    extends BaseController
+    with RequestMarkerContext {
   override protected def controllerComponents: ControllerComponents = pcc
 
   def PostAction: PostActionBuilder = pcc.postActionBuilder

--- a/app/v1/post/PostController.scala
+++ b/app/v1/post/PostController.scala
@@ -14,7 +14,8 @@ case class PostFormInput(title: String, body: String)
 /**
   * Takes HTTP requests and produces JSON.
   */
-class PostController @Inject()(cc: PostControllerComponents)(implicit ec: ExecutionContext)
+class PostController @Inject()(cc: PostControllerComponents)(
+    implicit ec: ExecutionContext)
     extends PostBaseController(cc) {
 
   private val logger = Logger(getClass)
@@ -42,14 +43,16 @@ class PostController @Inject()(cc: PostControllerComponents)(implicit ec: Execut
     processJsonPost()
   }
 
-  def show(id: String): Action[AnyContent] = PostAction.async { implicit request =>
-    logger.trace(s"show: id = $id")
-    postResourceHandler.lookup(id).map { post =>
-      Ok(Json.toJson(post))
-    }
+  def show(id: String): Action[AnyContent] = PostAction.async {
+    implicit request =>
+      logger.trace(s"show: id = $id")
+      postResourceHandler.lookup(id).map { post =>
+        Ok(Json.toJson(post))
+      }
   }
 
-  private def processJsonPost[A]()(implicit request: PostRequest[A]): Future[Result] = {
+  private def processJsonPost[A]()(
+      implicit request: PostRequest[A]): Future[Result] = {
     def failure(badForm: Form[PostFormInput]) = {
       Future.successful(BadRequest(badForm.errorsAsJson))
     }

--- a/app/v1/post/PostRepository.scala
+++ b/app/v1/post/PostRepository.scala
@@ -21,8 +21,8 @@ object PostId {
   }
 }
 
-
-class PostExecutionContext @Inject()(actorSystem: ActorSystem) extends CustomExecutionContext(actorSystem, "repository.dispatcher")
+class PostExecutionContext @Inject()(actorSystem: ActorSystem)
+    extends CustomExecutionContext(actorSystem, "repository.dispatcher")
 
 /**
   * A pure non-blocking interface for the PostRepository.
@@ -43,7 +43,8 @@ trait PostRepository {
   * such as rendering.
   */
 @Singleton
-class PostRepositoryImpl @Inject()()(implicit ec: PostExecutionContext) extends PostRepository {
+class PostRepositoryImpl @Inject()()(implicit ec: PostExecutionContext)
+    extends PostRepository {
 
   private val logger = Logger(this.getClass)
 
@@ -62,7 +63,8 @@ class PostRepositoryImpl @Inject()()(implicit ec: PostExecutionContext) extends 
     }
   }
 
-  override def get(id: PostId)(implicit mc: MarkerContext): Future[Option[PostData]] = {
+  override def get(id: PostId)(
+      implicit mc: MarkerContext): Future[Option[PostData]] = {
     Future {
       logger.trace(s"get: id = $id")
       postList.find(post => post.id == id)

--- a/app/v1/post/PostResourceHandler.scala
+++ b/app/v1/post/PostResourceHandler.scala
@@ -36,7 +36,8 @@ class PostResourceHandler @Inject()(
     routerProvider: Provider[PostRouter],
     postRepository: PostRepository)(implicit ec: ExecutionContext) {
 
-  def create(postInput: PostFormInput)(implicit mc: MarkerContext): Future[PostResource] = {
+  def create(postInput: PostFormInput)(
+      implicit mc: MarkerContext): Future[PostResource] = {
     val data = PostData(PostId("999"), postInput.title, postInput.body)
     // We don't actually create the post, so return what we have
     postRepository.create(data).map { id =>
@@ -44,7 +45,8 @@ class PostResourceHandler @Inject()(
     }
   }
 
-  def lookup(id: String)(implicit mc: MarkerContext): Future[Option[PostResource]] = {
+  def lookup(id: String)(
+      implicit mc: MarkerContext): Future[Option[PostResource]] = {
     val postFuture = postRepository.get(PostId(id))
     postFuture.map { maybePostData =>
       maybePostData.map { postData =>

--- a/build.sbt
+++ b/build.sbt
@@ -2,19 +2,28 @@ import sbt.Keys._
 
 lazy val GatlingTest = config("gatling") extend Test
 
-// This must be set to 2.11.11 because Gatling does not run on 2.12.2
-scalaVersion in ThisBuild := "2.11.11"
+inThisBuild(
+  List(
+    scalaVersion := "2.12.3",
+    dependencyOverrides := Set(
+       "com.google.code.findbugs" % "jsr305" % "3.0.1",
+       "com.google.guava" % "guava" % "22.0",
+       "com.typesafe.akka" %% "akka-stream" % "2.5.4",
+       "com.typesafe.akka" %% "akka-actor" % "2.5.4"
+    )
+  )
+)
 
 libraryDependencies += guice
-libraryDependencies += "org.joda" % "joda-convert" % "1.8"
-libraryDependencies += "net.logstash.logback" % "logstash-logback-encoder" % "4.9"
+libraryDependencies += "org.joda" % "joda-convert" % "1.8.3"
+libraryDependencies += "net.logstash.logback" % "logstash-logback-encoder" % "4.11"
 
-libraryDependencies += "com.netaporter" %% "scala-uri" % "0.4.16"
+libraryDependencies += "io.lemonlabs" %% "scala-uri" % "0.5.0"
 libraryDependencies += "net.codingwell" %% "scala-guice" % "4.1.0"
 
-libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "3.0.0-M3" % Test
-libraryDependencies += "io.gatling.highcharts" % "gatling-charts-highcharts" % "2.2.2" % Test
-libraryDependencies += "io.gatling" % "gatling-test-framework" % "2.2.2" % Test
+libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.1" % "test"
+libraryDependencies += "io.gatling.highcharts" % "gatling-charts-highcharts" % "2.3.0" % Test
+libraryDependencies += "io.gatling" % "gatling-test-framework" % "2.3.0" % Test
 
 // The Play project itself
 lazy val root = (project in file("."))

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -21,7 +21,7 @@ object Common extends AutoPlugin {
       "-deprecation",
       "-feature",
       "-unchecked",
-      "-Xlint",
+      "-Xlint:_,-unused", // work around for https://github.com/playframework/playframework/issues/7519
       "-Yno-adapted-args",
       "-Ywarn-numeric-widen",
       "-Xfatal-warnings"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,12 +2,12 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")
 
 // sbt-paradox, used for documentation
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.2.9")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.2.13")
 
 // Load testing tool:
-// http://gatling.io/docs/2.2.2/extensions/sbt_plugin.html
-addSbtPlugin("io.gatling" % "gatling-sbt" % "2.2.1")
+// http://gatling.io/docs/current/extensions/sbt_plugin.html
+addSbtPlugin("io.gatling" % "gatling-sbt" % "2.2.2")
 
 // Scala formatting: "sbt scalafmt"
-// https://olafurpg.github.io/scalafmt
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.3.1")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.10")
+    


### PR DESCRIPTION
Some knock-on effects from updating to 2.12 and upgrading libraries (including the scalafmt rules), but the major one is gatling-sbt 2.2.2