### PR TITLE
Upgrade branch 2.6.x using TemplateControl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,11 @@ dependencies {
     play "net.logstash.logback:logstash-logback-encoder:4.11"
 
     play "com.netaporter:scala-uri_$scalaVersion:0.4.16"
-    play "net.codingwell:scala-guice_\$scalaVersion:4.2.1"
+    play "net.codingwell:scala-guice_$scalaVersion:4.2.1"
 
-    playTest "org.scalatestplus.play:scalatestplus-play_\$scalaVersion:3.1.2"
-    playTest "io.gatling.highcharts:gatling-charts-highcharts:\$gatlingVersion"
-    playTest "io.gatling:gatling-test-framework:\$gatlingVersion"
+    playTest "org.scalatestplus.play:scalatestplus-play_$scalaVersion:3.1.2"
+    playTest "io.gatling.highcharts:gatling-charts-highcharts:$gatlingVersion"
+    playTest "io.gatling:gatling-test-framework:$gatlingVersion"
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "com.github.lkishalmi.gatling" version "0.7.1"
 }
 
-def playVersion = "2.6.20"
+def playVersion = "2.6.21"
 def scalaVersion = System.getProperty("scala.binary.version", /* default = */ "2.12")
 def gatlingVersion = "2.3.0"
 
@@ -44,11 +44,11 @@ dependencies {
     play "net.logstash.logback:logstash-logback-encoder:4.11"
 
     play "com.netaporter:scala-uri_$scalaVersion:0.4.16"
-    play "net.codingwell:scala-guice_$scalaVersion:4.2.1"
+    play "net.codingwell:scala-guice_\$scalaVersion:4.2.1"
 
-    playTest "org.scalatestplus.play:scalatestplus-play_$scalaVersion:3.1.2"
-    playTest "io.gatling.highcharts:gatling-charts-highcharts:$gatlingVersion"
-    playTest "io.gatling:gatling-test-framework:$gatlingVersion"
+    playTest "org.scalatestplus.play:scalatestplus-play_\$scalaVersion:3.1.2"
+    playTest "io.gatling.highcharts:gatling-charts-highcharts:\$gatlingVersion"
+    playTest "io.gatling:gatling-test-framework:\$gatlingVersion"
 }
 
 repositories {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.21")
 
 // sbt-paradox, used for documentation
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.3.3")


### PR DESCRIPTION
```
Updated with template-control on 2019-01-08T14:44:42.202Z
  **/plugins.sbt:
    addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.21")
  **build.gradle:
    def playVersion = "2.6.21"
  **build.gradle:
        play "net.codingwell:scala-guice_\$scalaVersion:4.2.1"
  **build.gradle:
        playTest "org.scalatestplus.play:scalatestplus-play_\$scalaVersion:3.1.2"
  **build.gradle:
        playTest "io.gatling.highcharts:gatling-charts-highcharts:\$gatlingVersion"
  **build.gradle:
        playTest "io.gatling:gatling-test-framework:\$gatlingVersion"

```
          